### PR TITLE
Added access to the BareMetalHost resources.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,3 +26,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+    - metal3.io
+  resources:
+    - baremetalhosts
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - metal3.io
+  resources:
+    - baremetalhosts/status
+  verbs:
+    - get
+    - patch
+    - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,20 @@ rules:
 - apiGroups:
   - metal3.io
   resources:
+  - baremetalhosts
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts/status
+  verbs:
+  - get
+- apiGroups:
+  - metal3.io
+  resources:
   - hardwareclassifications
   verbs:
   - create
@@ -26,23 +40,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-    - metal3.io
-  resources:
-    - baremetalhosts
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - metal3.io
-  resources:
-    - baremetalhosts/status
-  verbs:
-    - get
-    - patch
-    - update

--- a/controllers/hardwareclassification_controller.go
+++ b/controllers/hardwareclassification_controller.go
@@ -36,6 +36,10 @@ type HardwareClassificationReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwareclassifications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwareclassifications/status,verbs=get;update;patch
 
+// Add RBAC rules to access baremetalhost resources
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;update
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts/status,verbs=get
+
 func (r *HardwareClassificationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("hardwareclassification", req.NamespacedName)


### PR DESCRIPTION
The HardwareClassification controller needs access to the BareMetalHost resource. This patch adds that necessary access to the ClusterRole.

Respective Issue-: 
https://github.com/metal3-io/hardware-classification-controller/issues/15