### PR TITLE
Changed namespace to hardware-classification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ uninstall: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: hardware-classification
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: hardware-classification-controller-
+namePrefix: hardware-classification-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- namespace.yaml
+
+bases:
+- default        

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/namespace.yaml
+++ b/config/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: hardware-classification

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,6 +13,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
   - update
 - apiGroups:
   - metal3.io

--- a/controllers/hardwareclassification_controller.go
+++ b/controllers/hardwareclassification_controller.go
@@ -44,7 +44,7 @@ type HardwareClassificationReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwareclassifications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hardwareclassifications/status,verbs=get;update;patch
 // Add RBAC rules to access baremetalhost resources
-// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;update
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts/status,verbs=get
 func (hcReconciler *HardwareClassificationReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -49,9 +49,12 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var watchNamespace string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&watchNamespace, "namespace", "",
+                "Namespace that the controller watches to reconcile HWCC objects. If unspecified, the controller watches for HWCC objects across all namespaces.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -63,6 +66,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		Port:               9443,
+		Namespace:          watchNamespace,
 	})
 
 	if err != nil {


### PR DESCRIPTION
In this PR, changed namespace from system to hardware-classification and changed controller-manager name to  hardware-classification-controller-manager.
@digambar15 @maelk kindly review.  