### PR TITLE
leader election id must be configured.

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-hwcc",
 		Port:               9443,
 	})
 


### PR DESCRIPTION
This Fix is for Error found in container logs which led HWCC Pod into CrashloopBackOff.

2020-07-06T19:36:51.796Z        ERROR   setup   unable to start manager {"error": "LeaderElectionID must be configured"}
github.com/go-logr/zapr.(*zapLogger).Error
        /go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
main.main
        /workspace/main.go:69
runtime.main
        /usr/local/go/src/runtime/proc.go:203