### PR TITLE
Add manifest linting script

### DIFF
--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+# --strict: Disallow additional properties not in schema.
+# --ignore-missing-schemas: Skip validation for resource 
+# definitions without a schema. This will skip the checks
+# for the Custom Resource Definitions(CRDs).
+# -d, --directories strings: A comma-separated list of
+# directories to recursively search for YAML documents.
+# -i, --ignored-filename-patterns strings: A comma-separated
+# list of regular expressions specifying filenames to ignore.
+# -o, --output string: The format of the output of this script.
+# Options are: [stdout json tap].
+
+# We are skipping validation for the files that
+# matches our regexp pattern (i.e. kustom, patch). 
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    kubeval --strict --ignore-missing-schemas \
+    -d config -i kustom,patch -o tap
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    garethr/kubeval:latest \
+    /workdir/hack/manifestlint.sh "${@}"
+fi;


### PR DESCRIPTION
Add a script for validation of the k8s core objects within the
repo. This is the first step to have a mandatory CI job on every
future pull request. The second step will be to configure the prow
to run the script.

There are some files such as kustomization
patches for which we need to skip the validation because their
deployment definitions are not complete. As such, kubeval will
through an error for them. However, we can give a pattern of the
files in the same directory that need to be skipped from the check.
That's why we add the word patch in all the kustomization patches
so that we can filter them out with a single pattern, which in this
case is patch.