### PR TITLE
Bump the Golang version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/hardware-classification-controller
 
-go 1.14
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.2.1

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -19,6 +19,6 @@ else
     --volume "${PWD}:/workdir:rw,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /workdir/hack/gofmt.sh "${@}"
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -15,6 +15,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/hardware-classification-controller:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/hardware-classification-controller \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /go/src/github.com/metal3-io/hardware-classification-controller/hack/govet.sh "${@}"
 fi;


### PR DESCRIPTION
Bump the Golang version to [1.16](https://blog.golang.org/go1.16)
/hold until metal3-io/project-infra#172 gets merged
/cc @maelk 
