### PR TITLE
Corrected maxCount value for disk

### DIFF
--- a/classifier/disk.go
+++ b/classifier/disk.go
@@ -44,7 +44,7 @@ func checkDisks(profile *hwcc.HardwareClassification, host *bmh.BareMetalHost) b
 		"profile", profile.Name,
 		"namespace", host.Namespace,
 		"minCount", diskDetails.MinimumCount,
-		"maxCount", diskDetails.MinimumCount,
+		"maxCount", diskDetails.MaximumCount,
 		"actualCount", len(newDisk),
 		"ok", ok,
 	)


### PR DESCRIPTION
As in logs, minCount and maxCount for disk are showing same, I corrected the maxCount output which was taking minimumCount value to maximumCount value in disk.go within classifier.