### PR TITLE
Adding feature HWCC status field No BareMetalHosts found.

### DIFF
--- a/api/v1alpha1/hardwareclassification_types.go
+++ b/api/v1alpha1/hardwareclassification_types.go
@@ -190,6 +190,9 @@ const (
 	// ProfileMatchStatusUnMatched is the status value when the profile
 	// does not match to one of the BareMetalHost.
 	ProfileMatchStatusUnMatched ProfileMatchStatus = "unmatched"
+	// NoBareMetalHosts is the status value when the profile
+	// does not found no BareMetalHosts.
+	NoBareMetalHosts ProfileMatchStatus = "No BareMetalHosts Found"
 )
 
 // ErrorType indicates the class of problem that has caused the HCC resource

--- a/controllers/hardwareclassification_controller.go
+++ b/controllers/hardwareclassification_controller.go
@@ -138,6 +138,10 @@ func (hcReconciler *HardwareClassificationReconciler) Reconcile(req ctrl.Request
 	if matchCount == 0 {
 		status = hwcc.ProfileMatchStatusUnMatched
 	}
+	if len(bmhHostList.Items) == 0 {
+		status = hwcc.NoBareMetalHosts
+	}
+
 	if hardwareClassification.Status.ProfileMatchStatus != status {
 		hwcLog.Info("updating match status", "newValue", status)
 		hardwareClassification.Status.ProfileMatchStatus = status


### PR DESCRIPTION
Adding 1 more field in HWCC status. Whenever there is no BareMetalHosts are present, HWCC status will show "No BareMetalHosts found".