### PR TITLE
Fixing kustomize installation path issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := $(PWD)/hack/tools/bin
-KUSTOMIZE := $(BIN_DIR)/kustomize
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 COVER_PROFILE = cover.out
 KUBEBUILDER := $(TOOLS_BIN_DIR)/kubebuilder
@@ -82,9 +81,6 @@ docker-build: test
 # Push the docker image
 docker-push:
 	docker push ${IMG}
-
-$(KUSTOMIZE):
-	./hack/tools/install_kustomize.sh
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/hack/tools/install_kubebuilder.sh
+++ b/hack/tools/install_kubebuilder.sh
@@ -5,11 +5,11 @@
 version=2.2.0
 arch=amd64
 
-mkdir -p ./bin
+mkdir -p ./hack/tools/bin
 curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
 
 tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
-mv kubebuilder_${version}_linux_${arch}/bin/* bin
+mv kubebuilder_${version}_linux_${arch}/bin/* ./hack/tools/bin
 
 rm kubebuilder_${version}_linux_${arch}.tar.gz
 rm -r kubebuilder_${version}_linux_${arch}

--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -8,15 +8,15 @@ verify_kustomize_version() {
 
   echo "Verifying kustomize version"
   # If kustomize is available on the path, verify the version
-  if [ -x "$(command -v ./bin/kustomize)" ]; then
+  if [ -x "$(command -v ./hack/tools/bin/kustomize)" ]; then
     local kustomize_version
-    kustomize_version=$(./bin/kustomize version | grep -P '(?<=kustomize/v)[0-9]+\.[0-9]+\.[0-9]+' -o)
+    kustomize_version=$(./hack/tools/bin/kustomize version | grep -P '(?<=kustomize/v)[0-9]+\.[0-9]+\.[0-9]+' -o)
     if [[ "${MINIMUM_KUSTOMIZE_VERSION}" != $(echo -e "${MINIMUM_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
       case "${OSTYPE}" in
 	linux-gnu|darwin*)
 	  echo "Kustomize version ${kustomize_version}, expected ${MINIMUM_KUSTOMIZE_VERSION}"
 	  echo "Updating, removing the old version"
-	  rm ./bin/kustomize
+	  rm ./hack/tools/bin/kustomize
 	  ;;
 	*)
 	  cat <<EOF
@@ -31,7 +31,7 @@ EOF
   fi
 
   # If kustomize is not available on the path, get it
-  if ! [ -x "$(command -v ./bin/kustomize)" ]; then
+  if ! [ -x "$(command -v ./hack/tools/bin/kustomize)" ]; then
     case "${OSTYPE}" in
       linux-gnu)
 	OS='linux'
@@ -45,12 +45,12 @@ EOF
 	;;
     esac
     echo 'kustomize not found, installing'
-    if ! [ -d "./bin" ]; then
-      mkdir -p "./bin"
+    if ! [ -d "./hack/tools/bin" ]; then
+      mkdir -p "./hack/tools/bin"
     fi
     curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${MINIMUM_KUSTOMIZE_VERSION}/kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"
     tar -xzvf kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz
-    mv kustomize ./bin
+    mv kustomize ./hack/tools/bin
     rm kustomize_v${MINIMUM_KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz
   fi
 }


### PR DESCRIPTION
Kustomize installation path was different.
It was creating error while running CRD.
Fixes [Issue-84](https://github.com/metal3-io/hardware-classification-controller/issues/84)


Kindly review @zaneb @digambar15 @ravipwaghmare.