### PR TITLE
Modify OWNERS to keep the repository maintainable

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,10 @@
 
 approvers:
  - zaneb
- - digambar15
+ - ravipwaghmare
+ - ashughorla
+
+emeritus_approvers:
  - russellb
  - maelk
-
-reviewers:
- - ashughorla
- - ravipwaghmare
+ - digambar15


### PR DESCRIPTION
3 of the 4 approvers have left the project thus the PRs are
not getting reviewd and approved in reasonable time scale thus the
development is greatly slowed down.

This change moves one reviewer to the approver list and moves
inactive approvers to the emeritus_approvers list.