### PR TITLE
markdownlint: pin to 0.12.0

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -17,7 +17,7 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
     /workdir/hack/markdownlint.sh "${@}"
 fi;
 


### PR DESCRIPTION
mdl 0.12.0 changes unordered list indentation from 2 to 3, which has caused problems in many other repositories. Pin mdl to 0.12.0 so the linter does not change without intention in future. SHA is added to make security bots happy by pinning this dependency down.

https://github.com/markdownlint/markdownlint/pull/373
